### PR TITLE
Impl toMap

### DIFF
--- a/src/components/useThree/mainCanvas.tsx
+++ b/src/components/useThree/mainCanvas.tsx
@@ -20,6 +20,14 @@ export const MainCanvas = (props: Props) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const orbitControlsRef = useRef<any>(null);
 
+  const handleOrbitControlsChange = () => {
+    const orbitControls = orbitControlsRef.current;
+    if (!orbitControls) return;
+    if (orbitControls.getDistance() === orbitControls.minDistance) {
+      setIsMap(true);
+    }
+  };
+
   return (
     <Canvas
       camera={{
@@ -37,13 +45,7 @@ export const MainCanvas = (props: Props) => {
         minDistance={150}
         maxDistance={500}
         enablePan={false}
-        onChange={() => {
-          const orbitControls = orbitControlsRef.current;
-          if (!orbitControls) return;
-          if (orbitControls.getDistance() == orbitControls.minDistance) {
-            setIsMap(true);
-          }
-        }}
+        onChange={handleOrbitControlsChange}
       />
       <Moon
         option={option}

--- a/src/components/useThree/mainCanvas.tsx
+++ b/src/components/useThree/mainCanvas.tsx
@@ -1,5 +1,6 @@
 import { OrbitControls } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
+import { useRef } from "react";
 import { Moon } from "./moon";
 import { Universe } from "./universe";
 import type { MoonquakeData } from "@/type";
@@ -16,19 +17,34 @@ export const MainCanvas = (props: Props) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { moonquakeData, setIsMap, option, choiceMoonquake, setChoiceMoonquake } = props;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const orbitControlsRef = useRef<any>(null);
+
   return (
     <Canvas
       camera={{
         fov: 45,
         near: 0.1,
         far: 1000,
-        position: [0, 0, 0],
+        position: [0, 300, 0],
       }}
       style={{ background: "black" }}
     >
       <directionalLight position={[1, 1, 1]} intensity={0.8} />
       <ambientLight args={[0xffffff]} intensity={0.5} />
-      <OrbitControls minDistance={250} maxDistance={500} enablePan={false} />
+      <OrbitControls
+        ref={orbitControlsRef}
+        minDistance={150}
+        maxDistance={500}
+        enablePan={false}
+        onChange={() => {
+          const orbitControls = orbitControlsRef.current;
+          if (!orbitControls) return;
+          if (orbitControls.getDistance() == orbitControls.minDistance) {
+            setIsMap(true);
+          }
+        }}
+      />
       <Moon
         option={option}
         moonquakeData={moonquakeData}

--- a/src/components/useThree/mainCanvas.tsx
+++ b/src/components/useThree/mainCanvas.tsx
@@ -15,7 +15,6 @@ type Props = {
   setChoiceMoonquake: React.Dispatch<React.SetStateAction<MoonquakeData | null>>;
 };
 export const MainCanvas = (props: Props) => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { moonquakeData, setIsMap, option, choiceMoonquake, setChoiceMoonquake } = props;
 
   const orbitControlsRef = useRef<OrbitControlsImpl>(null);

--- a/src/components/useThree/mainCanvas.tsx
+++ b/src/components/useThree/mainCanvas.tsx
@@ -23,7 +23,7 @@ export const MainCanvas = (props: Props) => {
   const handleOrbitControlsChange = () => {
     const orbitControls = orbitControlsRef.current;
     if (!orbitControls) return;
-    if (orbitControls.getDistance() === orbitControls.minDistance) {
+    if (orbitControls.getDistance() <= orbitControls.minDistance) {
       setIsMap(true);
     }
   };

--- a/src/components/useThree/mainCanvas.tsx
+++ b/src/components/useThree/mainCanvas.tsx
@@ -1,7 +1,7 @@
 import { OrbitControls } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
 import { useRef } from "react";
-import { OrbitControls as OrbitControlsImpl } from "three-stdlib";
+import type { OrbitControls as OrbitControlsImpl } from "three-stdlib";
 import { Moon } from "./moon";
 import { Universe } from "./universe";
 import type { MoonquakeData } from "@/type";

--- a/src/components/useThree/mainCanvas.tsx
+++ b/src/components/useThree/mainCanvas.tsx
@@ -1,6 +1,7 @@
 import { OrbitControls } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
 import { useRef } from "react";
+import { OrbitControls as OrbitControlsImpl } from "three-stdlib";
 import { Moon } from "./moon";
 import { Universe } from "./universe";
 import type { MoonquakeData } from "@/type";
@@ -17,8 +18,7 @@ export const MainCanvas = (props: Props) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { moonquakeData, setIsMap, option, choiceMoonquake, setChoiceMoonquake } = props;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const orbitControlsRef = useRef<any>(null);
+  const orbitControlsRef = useRef<OrbitControlsImpl>(null);
 
   const handleOrbitControlsChange = () => {
     const orbitControls = orbitControlsRef.current;


### PR DESCRIPTION
## 概要

Three状態で月に近づくと、Map状態に代わるように

### やったこと

- `orbitControls`のdistanceがminDistanceに一致したときにMapに遷移するようにした

### やらなかったこと(あれば)

- minDistanceのいい感じの調整(適当な値になってる、でも問題ないかも)
- 右下のtoMap/toThree ボタンの削除
  - ~~スマホからだとMap/Threeへの遷移が行われていなさそう？~~
  - スマホだと toMap は上手くいっているが toThree が上手くいっていない

## スクリーンショット

## 破壊的変更があるか(あれば内容を記載)

- [ ] YES
- [x] NO

## チェック項目

- [ ] lintが通る
- [x] 複雑なコードにはコメントを記載してある

## 関連Issue

## レビュワーへのコメント

```typescript
// eslint-disable-next-line @typescript-eslint/no-explicit-any
const orbitControlsRef = useRef<any>(null);
```
と書いてしまっています、本当にごめんなさい。
```typescript
const orbitControlsRef = useRef<OrbitControls>(null);
```
と書くべきなんですが、
`'OrbitControls' refers to a value, but is being used as a type here. Did you mean 'typeof OrbitControls'?ts(2749)
type OrbitControls = /*unresolved*/ any` とエラーになってしまったので `any` を使っています。



