### PR TITLE
いろいろした

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -6,7 +6,6 @@ import {
   Stack,
   VStack,
   Text,
-  Checkbox,
   Slider,
   SliderTrack,
   SliderFilledTrack,
@@ -15,14 +14,10 @@ import {
   Divider,
   Radio,
   RadioGroup,
-  RangeSlider,
-  RangeSliderFilledTrack,
-  RangeSliderTrack,
-  RangeSliderThumb,
 } from "@chakra-ui/react";
-import { AiOutlineClose, AiOutlineMenu, AiFillInfoCircle } from "react-icons/ai";
-import { MoonquakeType } from "@/type/moon";
-import { Option, OptionConstants } from "@/type/option";
+import { AiOutlineClose, AiOutlineMenu } from "react-icons/ai";
+import { SwitchSetting, TypeFilterSetting, YearSlider } from "@/components/useHeader";
+import { Option } from "@/type/option";
 
 type Props = {
   option: Option;
@@ -32,6 +27,7 @@ type Props = {
 export const Header = (props: Props) => {
   const { option, setOption } = props;
   const { isOpen, onToggle } = useDisclosure();
+  const width = { base: "100%", sm: "280px" };
   return (
     <>
       <Box
@@ -39,9 +35,9 @@ export const Header = (props: Props) => {
         position="absolute"
         top={0}
         left={0}
-        w={isOpen ? "280px" : "0px"}
+        w={isOpen ? width : "0px"}
         h="100%"
-        zIndex={1}
+        zIndex={2}
         transition="0.1s"
       />
       <Box
@@ -50,8 +46,8 @@ export const Header = (props: Props) => {
         left={0}
         userSelect="none"
         h="fit-content"
-        w="280px"
-        zIndex={1}
+        w={width}
+        zIndex={2}
         opacity="70%"
         backdropFilter="blur(2px)"
       >
@@ -64,6 +60,7 @@ export const Header = (props: Props) => {
           color={isOpen ? "gray.600" : "gray.300"}
           onClick={onToggle}
           zIndex={10}
+          cursor="pointer"
         />
         <SlideFade in={isOpen} offsetX={-80} offsetY={0} unmountOnExit>
           <Box position="absolute" top="0px" left="0px" w="100%" h="60px" bgColor="gray.300" zIndex={5}>
@@ -72,16 +69,21 @@ export const Header = (props: Props) => {
           <VStack bgColor="gray.300" h="100vh" pt="72px" px="26px" gap={2} color="gray.600" overflowY="scroll">
             <TypeFilterSetting option={option} setOption={setOption} />
             <Divider borderColor="gray.600" pt={4} />
-            <Box w="100%">
+            <VStack w="100%" gap={1}>
               <Text fontSize={24} fontWeight="medium" pt={2}>
                 Settings
               </Text>
+              <SwitchSetting
+                name="Performance Mode"
+                checked={option.performanceMode}
+                onChange={() => setOption({ ...option, performanceMode: !option.performanceMode })}
+              />
               <SwitchSetting
                 name="Auto Rotate"
                 checked={option.autoRotate}
                 onChange={() => setOption({ ...option, autoRotate: !option.autoRotate })}
               />
-              <Box w="100%" pb={1}>
+              <Box w="100%">
                 <Switch size="md" colorScheme="teal" defaultChecked fontSize={18}>
                   Height Map
                 </Switch>
@@ -91,7 +93,7 @@ export const Header = (props: Props) => {
                   Lunar eclipse
                 </Switch>
               </Box>
-            </Box>
+            </VStack>
             <Divider borderColor="gray.600" pt={4} />
             <Box w="100%" pt={2}>
               <Text fontSize={24} fontWeight="medium">
@@ -160,104 +162,5 @@ export const Header = (props: Props) => {
         </SlideFade>
       </Box>
     </>
-  );
-};
-
-type SwitchSettingProps = {
-  name: string;
-  checked: boolean;
-  onChange: () => void;
-};
-
-const SwitchSetting = (props: SwitchSettingProps) => {
-  const { name, checked, onChange } = props;
-  return (
-    <Box w="100%" pt={2} pb={1}>
-      <Switch size="md" colorScheme="teal" fontSize={18} isChecked={checked} onChange={onChange}>
-        {name}
-      </Switch>
-    </Box>
-  );
-};
-
-type YearSliderProps = {
-  option: Option;
-  setOption: React.Dispatch<React.SetStateAction<Option>>;
-};
-
-const YearSlider = (props: YearSliderProps) => {
-  const { option, setOption } = props;
-  const isAll = option.minYear === OptionConstants.minYear && option.maxYear === OptionConstants.maxYear;
-  const label = isAll ? "All" : `${option.minYear} - ${option.maxYear}`;
-
-  return (
-    <Box w="100%">
-      <Text fontSize={24} fontWeight="medium" pt={2}>
-        Year
-      </Text>
-      <Text fontSize={20} pb={2}>
-        {" "}
-        Range: <Text as="span">{label}</Text>
-      </Text>
-      <RangeSlider
-        min={OptionConstants.minYear}
-        max={OptionConstants.maxYear}
-        defaultValue={[option.minYear, option.maxYear]}
-        onChange={(value) => setOption({ ...option, minYear: value[0], maxYear: value[1] })}
-        colorScheme="teal"
-      >
-        <RangeSliderTrack>
-          <RangeSliderFilledTrack />
-        </RangeSliderTrack>
-        <RangeSliderThumb index={0} />
-        <RangeSliderThumb index={1} />
-      </RangeSlider>
-    </Box>
-  );
-};
-
-type TypeFilterSettingProps = {
-  option: Option;
-  setOption: React.Dispatch<React.SetStateAction<Option>>;
-};
-
-const TypeFilterSetting = (props: TypeFilterSettingProps) => {
-  const { option, setOption } = props;
-
-  const changetypeFilter = (type: MoonquakeType) => {
-    const typeFilter = option.typeFilter;
-    if (typeFilter.has(type)) {
-      typeFilter.delete(type);
-    } else {
-      typeFilter.add(type);
-    }
-    setOption({ ...option, typeFilter: typeFilter });
-  };
-
-  return (
-    <Box w="100%">
-      <Text fontSize={24} fontWeight="medium">
-        Filter
-      </Text>
-      <Text fontSize={12}>
-        <Icon as={AiFillInfoCircle} fontSize={12} mr="8px" />
-        Click to filter.
-      </Text>
-      <Box w="100%" pt={3} pb={1}>
-        <Checkbox size="lg" colorScheme="teal" onChange={() => changetypeFilter(0)} defaultChecked>
-          Shallow
-        </Checkbox>
-      </Box>
-      <Box w="100%" pb={1}>
-        <Checkbox size="lg" colorScheme="teal" onChange={() => changetypeFilter(1)} defaultChecked>
-          Deep
-        </Checkbox>
-      </Box>
-      <Box w="100%">
-        <Checkbox size="lg" colorScheme="teal" onChange={() => changetypeFilter(2)} defaultChecked>
-          Artifical
-        </Checkbox>
-      </Box>
-    </Box>
   );
 };

--- a/src/components/loadingBox.tsx
+++ b/src/components/loadingBox.tsx
@@ -1,0 +1,31 @@
+import { Spinner, Text, Flex, VStack } from "@chakra-ui/react";
+
+type Props = {
+  loadingPageStep: number;
+};
+export const LoadingBox = (props: Props) => {
+  const { loadingPageStep } = props;
+  return (
+    <>
+      {loadingPageStep < 2 && (
+        <Flex
+          position="absolute"
+          top={0}
+          left={0}
+          w="100%"
+          h="100%"
+          zIndex={100}
+          bgColor="black"
+          align="center"
+          justify="center"
+        >
+          <VStack>
+            <Spinner color="white" speed="0.8s" size="xl" />
+            <Text color="white">Loading progress</Text>
+            <Text color="white"> ( {loadingPageStep + 1} / 2 )</Text>
+          </VStack>
+        </Flex>
+      )}
+    </>
+  );
+};

--- a/src/components/main.tsx
+++ b/src/components/main.tsx
@@ -1,6 +1,7 @@
 import { Box, Button } from "@chakra-ui/react";
 import React, { useState, useEffect } from "react";
 import { Header } from "./header";
+import { LoadingBox } from "./loadingBox";
 import { MapComponent } from "./mapLibre";
 import { Panel } from "./panel";
 import { MainCanvas } from "./useThree/mainCanvas";
@@ -16,16 +17,20 @@ export const Main = () => {
     minYear: OptionConstants.minYear,
     maxYear: OptionConstants.maxYear,
     typeFilter: OptionConstants.typeFilter,
+    performanceMode: OptionConstants.performanceMode,
   });
+  const [loadingPageStep, setLoadingPageStep] = useState(0);
   const [choiceMoonquake, setChoiceMoonquake] = useState<MoonquakeData | null>(null);
 
   useEffect(() => {
+    setLoadingPageStep(1);
     const fetchMoonquake = async () => {
       const shallowMoonquakes = await fetchShallowMoonquakeCSV();
       const deepMoonquakes = await fetchDeepMoonquakeCSV();
       const artificialImpacts = await fetchArtificialImpactCSV();
       const quakes = [...shallowMoonquakes, ...deepMoonquakes, ...artificialImpacts] as MoonquakeData[];
       setMoonquakeData(quakes);
+      setLoadingPageStep(2);
     };
     fetchMoonquake();
   }, []);
@@ -42,23 +47,30 @@ export const Main = () => {
         position={"absolute"}
         bottom={10}
         right={10}
-        zIndex={100}
+        zIndex={1}
       >
-        {isMap ? "toThree" : "toMap"}
+        {isMap ? "to 3D" : "to Map"}
       </Button>
 
-      <Box w="100%" h="100%" position="absolute" top={0} left={0} zIndex={isMap ? 0 : -1}>
-        <MapComponent setIsMap={setIsMap} setChoiceMoonquake={setChoiceMoonquake} />
-      </Box>
-      <Box w="100%" h="100%" position="absolute" top={0} left={0} zIndex={isMap ? -1 : 0}>
-        <MainCanvas
-          setIsMap={setIsMap}
-          moonquakeData={moonquakeData}
-          option={option}
-          choiceMoonquake={choiceMoonquake}
-          setChoiceMoonquake={setChoiceMoonquake}
-        />
-      </Box>
+      <LoadingBox loadingPageStep={loadingPageStep} />
+
+      {(isMap || !option.performanceMode) && (
+        <Box w="100%" h="100%" position="absolute" top={0} left={0} zIndex={isMap ? 0 : -1}>
+          <MapComponent setIsMap={setIsMap} setChoiceMoonquake={setChoiceMoonquake} />
+        </Box>
+      )}
+
+      {(!isMap || !option.performanceMode) && (
+        <Box w="100%" h="100%" position="absolute" top={0} left={0} zIndex={isMap ? -1 : 0}>
+          <MainCanvas
+            setIsMap={setIsMap}
+            moonquakeData={moonquakeData}
+            option={option}
+            choiceMoonquake={choiceMoonquake}
+            setChoiceMoonquake={setChoiceMoonquake}
+          />
+        </Box>
+      )}
     </Box>
   );
 };

--- a/src/components/useHeader/index.ts
+++ b/src/components/useHeader/index.ts
@@ -1,0 +1,3 @@
+export { SwitchSetting } from "./switchSetting";
+export { TypeFilterSetting } from "./typeFilterSetting";
+export { YearSlider } from "./yearSlider";

--- a/src/components/useHeader/switchSetting.tsx
+++ b/src/components/useHeader/switchSetting.tsx
@@ -1,0 +1,19 @@
+import { Box, Switch } from "@chakra-ui/react";
+
+type Props = {
+  name: string;
+  checked: boolean;
+  onChange: () => void;
+  colorScheme?: string;
+};
+
+export const SwitchSetting = (props: Props) => {
+  const { name, checked, onChange, colorScheme } = props;
+  return (
+    <Box w="100%">
+      <Switch size="md" colorScheme={colorScheme ?? "teal"} fontSize={18} isChecked={checked} onChange={onChange}>
+        {name}
+      </Switch>
+    </Box>
+  );
+};

--- a/src/components/useHeader/typeFilterSetting.tsx
+++ b/src/components/useHeader/typeFilterSetting.tsx
@@ -1,0 +1,49 @@
+import { Box, Text, Checkbox, Icon } from "@chakra-ui/react";
+import { AiFillInfoCircle } from "react-icons/ai";
+import { MoonquakeType, Option } from "@/type";
+
+type Props = {
+  option: Option;
+  setOption: React.Dispatch<React.SetStateAction<Option>>;
+};
+
+export const TypeFilterSetting = (props: Props) => {
+  const { option, setOption } = props;
+
+  const changetypeFilter = (type: MoonquakeType) => {
+    const typeFilter = option.typeFilter;
+    if (typeFilter.has(type)) {
+      typeFilter.delete(type);
+    } else {
+      typeFilter.add(type);
+    }
+    setOption({ ...option, typeFilter: typeFilter });
+  };
+
+  return (
+    <Box w="100%">
+      <Text fontSize={24} fontWeight="medium">
+        Filter
+      </Text>
+      <Text fontSize={12}>
+        <Icon as={AiFillInfoCircle} fontSize={12} mr="8px" />
+        Click to filter.
+      </Text>
+      <Box w="100%" pt={3} pb={1}>
+        <Checkbox size="lg" colorScheme="orange" onChange={() => changetypeFilter(0)} defaultChecked>
+          Shallow
+        </Checkbox>
+      </Box>
+      <Box w="100%" pb={1}>
+        <Checkbox size="lg" colorScheme="purple" onChange={() => changetypeFilter(1)} defaultChecked>
+          Deep
+        </Checkbox>
+      </Box>
+      <Box w="100%">
+        <Checkbox size="lg" colorScheme="blue" onChange={() => changetypeFilter(2)} defaultChecked>
+          Artifical
+        </Checkbox>
+      </Box>
+    </Box>
+  );
+};

--- a/src/components/useHeader/yearSlider.tsx
+++ b/src/components/useHeader/yearSlider.tsx
@@ -1,0 +1,39 @@
+import { Box, Text, RangeSlider, RangeSliderFilledTrack, RangeSliderTrack, RangeSliderThumb } from "@chakra-ui/react";
+import React from "react";
+import { Option, OptionConstants } from "@/type/option";
+
+type Props = {
+  option: Option;
+  setOption: React.Dispatch<React.SetStateAction<Option>>;
+};
+
+export const YearSlider = (props: Props) => {
+  const { option, setOption } = props;
+  const isAll = option.minYear === OptionConstants.minYear && option.maxYear === OptionConstants.maxYear;
+  const label = isAll ? "All" : `${option.minYear} - ${option.maxYear}`;
+
+  return (
+    <Box w="100%">
+      <Text fontSize={24} fontWeight="medium" pt={2}>
+        Year
+      </Text>
+      <Text fontSize={20} pb={2}>
+        {" "}
+        Range: <Text as="span">{label}</Text>
+      </Text>
+      <RangeSlider
+        min={OptionConstants.minYear}
+        max={OptionConstants.maxYear}
+        defaultValue={[option.minYear, option.maxYear]}
+        onChange={(value) => setOption({ ...option, minYear: value[0], maxYear: value[1] })}
+        colorScheme="teal"
+      >
+        <RangeSliderTrack>
+          <RangeSliderFilledTrack />
+        </RangeSliderTrack>
+        <RangeSliderThumb index={0} />
+        <RangeSliderThumb index={1} />
+      </RangeSlider>
+    </Box>
+  );
+};

--- a/src/components/useMapLibre/index.ts
+++ b/src/components/useMapLibre/index.ts
@@ -22,8 +22,6 @@ export const mapLibreLogic = (props: Props) => {
     container,
     zoom,
     dragRotate: false,
-    //dragPan: false,
-    touchZoomRotate: false,
     minPitch: 0,
     pitchWithRotate: false,
     renderWorldCopies: false,
@@ -66,6 +64,8 @@ export const mapLibreLogic = (props: Props) => {
     minZoom,
     maxZoom,
   });
+
+  map.touchZoomRotate.disableRotation();
 
   map.on("zoom", () => {
     // console.log(map.getZoom());

--- a/src/type/option.ts
+++ b/src/type/option.ts
@@ -1,6 +1,7 @@
 import { MoonquakeType } from "./moon";
 
 export type Option = {
+  performanceMode: boolean;
   autoRotate: boolean;
   minYear: number;
   maxYear: number;
@@ -9,6 +10,7 @@ export type Option = {
 
 export class OptionConstants {
   static readonly autoRotate = true;
+  static readonly performanceMode = false;
   static readonly minYear = 1965;
   static readonly maxYear = 1980;
   static readonly typeFilter = new Set<MoonquakeType>([0, 1, 2]);


### PR DESCRIPTION
## 概要

### やったこと

- Headerをいじった
  - コンポーネントを外部ファイルに移した(`useHeader`)
  - zindexをいじってヘッダーが一番上にした
  - SP時横幅が画面幅MAXになるようにした（レスポンシブ対応）
  - Filterのチェックボックスの色を実際の球に合わせた

| before | after |
|-|-|
| ![image](https://github.com/yudai1204/nasa-hackathon-2023-yokohama/assets/59430508/a6036a55-9ab9-48c5-bc44-e7d8bfeda8ac) | ![image](https://github.com/yudai1204/nasa-hackathon-2023-yokohama/assets/59430508/9258ec34-8aa4-4086-8c11-2c60c415430b) |

- Loading画面を作った
  - たまに初回ロードが重いときがあるので、Loading画面を作った

![image](https://github.com/yudai1204/nasa-hackathon-2023-yokohama/assets/59430508/8159b695-bbeb-4411-b79c-eade09beea87)


- パフォーマンスモードの追加
  - パフォーマンスモードがオンの時には地図と3Dの同時読込がされない

- 地図についてスマホでピンチイン・ピンチアウトのみ可能に

### やらなかったこと(あれば)

- やっていない部分（関連するこれから手を付ける予定の部分）

## スクリーンショット

## 破壊的変更があるか(あれば内容を記載)

- [ ] YES
- [x] NO

## チェック項目

- [x] lintが通る
- [ ] 複雑なコードにはコメントを記載してある

## 関連Issue

## レビュワーへのコメント
