### PR TITLE
ヒント表示の追加、Detailsのスマート切り替え

### DIFF
--- a/src/components/hint.tsx
+++ b/src/components/hint.tsx
@@ -1,0 +1,58 @@
+import { Flex, Text, Icon } from "@chakra-ui/react";
+import { css, keyframes } from "@emotion/react";
+import { useEffect, useState } from "react";
+import { CgScrollV } from "react-icons/cg";
+import { MdOutlinePinch } from "react-icons/md";
+import { useWideHeader } from "@/utils/useWideHeader";
+
+const bounce = keyframes`
+  0%, 100% {
+    transform: scale(1,1);
+    opacity: 0.6;
+  }
+
+  50% {
+    transform: scale(1.1,1.1);
+    opacity: 1;
+  }
+`;
+
+type Props = {
+  setDisplayHint: React.Dispatch<React.SetStateAction<boolean>>;
+};
+export const HintPopup = (props: Props) => {
+  const { setDisplayHint } = props;
+  const wideHeader = useWideHeader();
+  const [isSP, setIsSP] = useState(false);
+  useEffect(() => {
+    if (wideHeader) {
+      setIsSP(false);
+    } else {
+      setIsSP(true);
+    }
+  }, [wideHeader]);
+
+  return (
+    <Flex
+      zIndex={10}
+      position="absolute"
+      top="40%"
+      left={0}
+      w="100%"
+      align="center"
+      justify="center"
+      gap={4}
+      userSelect="none"
+      css={css`
+        animation: ${bounce} 3s ease-in-out infinite;
+      `}
+      onClick={() => setDisplayHint(false)}
+    >
+      <Icon as={isSP ? MdOutlinePinch : CgScrollV} fontSize={32} color="white" />
+      <Text fontSize={16} color="white">
+        {isSP ? "Pinch out" : "Scroll up"} and zoom
+        <br /> to switch to 2D map
+      </Text>
+    </Flex>
+  );
+};

--- a/src/components/main.tsx
+++ b/src/components/main.tsx
@@ -1,6 +1,7 @@
 import { Box } from "@chakra-ui/react";
 import React, { useState, useEffect } from "react";
 import { Header } from "./header";
+import { HintPopup } from "./hint";
 import { LoadingBox } from "./loadingBox";
 import { MapComponent } from "./mapLibre";
 import { Panel } from "./panel";
@@ -24,6 +25,7 @@ export const Main = () => {
   });
   const [loadingPageStep, setLoadingPageStep] = useState(0);
   const [choiceMoonquake, setChoiceMoonquake] = useState<MoonquakeData | null>(null);
+  const [displayHint, setDisplayHint] = useState(true);
 
   useEffect(() => {
     setLoadingPageStep(1);
@@ -50,6 +52,7 @@ export const Main = () => {
         ))}
 
       <LoadingBox loadingPageStep={loadingPageStep} />
+      {displayHint && <HintPopup setDisplayHint={setDisplayHint} />}
 
       {(isMap || !option.performanceMode) && (
         <Box w="100%" h="100%" position="absolute" top={0} left={0} zIndex={isMap ? 0 : -1}>
@@ -65,6 +68,7 @@ export const Main = () => {
             option={option}
             choiceMoonquake={choiceMoonquake}
             setChoiceMoonquake={setChoiceMoonquake}
+            setDisplayHint={setDisplayHint}
           />
         </Box>
       )}

--- a/src/components/panel.tsx
+++ b/src/components/panel.tsx
@@ -1,5 +1,5 @@
 import { Box, Text, VStack, Icon } from "@chakra-ui/react";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { MdDragIndicator } from "react-icons/md";
 import { MoonquakeData, isArtificialImpact, isDeepMoonquake, isShallowMoonquake } from "@/type";
 
@@ -48,9 +48,13 @@ type Props = {
 };
 
 export const Panel = (props: Props) => {
-  const [isOpen, setIsOpnen] = useState(true);
+  const [isOpen, setIsOpnen] = useState(false);
 
   const data = convertToData(props.choiceMoonquake);
+
+  useEffect(() => {
+    if (data.latitude && data.longitude) setIsOpnen(true);
+  }, [data.latitude, data.longitude]);
 
   return (
     <Box

--- a/src/components/useThree/mainCanvas.tsx
+++ b/src/components/useThree/mainCanvas.tsx
@@ -15,13 +15,15 @@ type Props = {
   option: Option;
   choiceMoonquake: MoonquakeData | null;
   setChoiceMoonquake: React.Dispatch<React.SetStateAction<MoonquakeData | null>>;
+  setDisplayHint: React.Dispatch<React.SetStateAction<boolean>>;
 };
 export const MainCanvas = (props: Props) => {
-  const { moonquakeData, setIsMap, option, choiceMoonquake, setChoiceMoonquake } = props;
+  const { moonquakeData, setIsMap, option, choiceMoonquake, setChoiceMoonquake, setDisplayHint } = props;
 
   const orbitControlsRef = useRef<OrbitControlsImpl>(null);
 
   const handleOrbitControlsChange = () => {
+    setDisplayHint(false);
     const orbitControls = orbitControlsRef.current;
     if (!orbitControls) return;
     if (orbitControls.getDistance() <= orbitControls.minDistance) {


### PR DESCRIPTION
## 概要

### やったこと

https://github.com/yudai1204/nasa-hackathon-2023-yokohama/issues/77

起動時に、「Zoomして2Dに切り替え」という表示を出すようにした。
スクロールすると消える。

また、起動時はDetailが閉じた状態で起動するようにし、地震をクリックすると自動で開くようにした

- やったことを書く（必須

### やらなかったこと(あれば)

- やっていない部分（関連するこれから手を付ける予定の部分）

## スクリーンショット
スマホ
<img width="401" alt="スクリーンショット 2023-10-12 22 41 13" src="https://github.com/yudai1204/nasa-hackathon-2023-yokohama/assets/59430508/8dd07c0e-baea-4b25-9722-83781ca7c5b9">

PC
<img width="1186" alt="スクリーンショット 2023-10-12 22 40 54" src="https://github.com/yudai1204/nasa-hackathon-2023-yokohama/assets/59430508/6b1f438f-fc9f-4b79-a502-943d07864cbe">


## 破壊的変更があるか(あれば内容を記載)

- [ ] YES
- [x] NO

## チェック項目

- [x] lintが通る
- [ ] 複雑なコードにはコメントを記載してある

## 関連Issue

## レビュワーへのコメント
